### PR TITLE
fix: The Width of the stream's CameraImage is width from the length of the pixels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+- The Width of the stream's CameraImage is width from the length of the pixels. #45
+
 ## 0.3.0
 
 - impl DetectResults #43

--- a/example/lib/providers/ncnn_yolox_controller.dart
+++ b/example/lib/providers/ncnn_yolox_controller.dart
@@ -67,7 +67,6 @@ class NcnnYoloxController extends StateNotifier<List<YoloxResults>> {
               y: cameraImage.planes[0].bytes,
               u: cameraImage.planes[1].bytes,
               v: cameraImage.planes[2].bytes,
-              width: cameraImage.width,
               height: cameraImage.height,
               deviceOrientationType:
                   _read(myCameraController).deviceOrientationType,
@@ -83,7 +82,6 @@ class NcnnYoloxController extends StateNotifier<List<YoloxResults>> {
         state = _ncnnYolox
             .detectBGRA8888(
               pixels: cameraImage.planes[0].bytes,
-              width: cameraImage.width,
               height: cameraImage.height,
               deviceOrientationType:
                   _read(myCameraController).deviceOrientationType,

--- a/lib/ncnn_yolox.dart
+++ b/lib/ncnn_yolox.dart
@@ -218,6 +218,8 @@ class NcnnYolox {
     required Uint8List u,
     required Uint8List v,
     required int height,
+    @Deprecated("width is automatically calculated from the length of the y.")
+        int width = 0,
     required KannaRotateDeviceOrientationType deviceOrientationType,
     required int sensorOrientation,
     void Function(ui.Image image)? onDecodeImage,
@@ -308,6 +310,8 @@ class NcnnYolox {
   DetectResults detectBGRA8888({
     required Uint8List pixels,
     required int height,
+    @Deprecated("width is automatically calculated from the length of the pixels.")
+        int width = 0,
     required KannaRotateDeviceOrientationType deviceOrientationType,
     required int sensorOrientation,
     void Function(ui.Image image)? onDecodeImage,

--- a/lib/ncnn_yolox.dart
+++ b/lib/ncnn_yolox.dart
@@ -198,7 +198,8 @@ class NcnnYolox {
   ///
   /// When detecting from an image byte array, specify [y], [u] and [v].
   /// [y] and [u] and [v] are the YUV420 data of the image.
-  /// [width] and [height] are the width and height of the image.
+  /// [height] is the height of the image.
+  /// The width of the image is calculated from [y] length.
   ///
   /// [deviceOrientationType] is the device orientation.
   /// It can be obtained from CameraController of the camera package.
@@ -216,7 +217,6 @@ class NcnnYolox {
     required Uint8List y,
     required Uint8List u,
     required Uint8List v,
-    required int width,
     required int height,
     required KannaRotateDeviceOrientationType deviceOrientationType,
     required int sensorOrientation,
@@ -228,6 +228,8 @@ class NcnnYolox {
       u: u,
       v: v,
     );
+
+    final width = y.length ~/ height;
 
     final pixels = yuv420sp2rgb(
       yuv420sp: yuv420sp,
@@ -288,7 +290,8 @@ class NcnnYolox {
   /// Run it after initYolox
   ///
   /// When detecting from an image byte array, specify [pixels].
-  /// [width] and [height] are the width and height of the image.
+  /// [height] is the height of the image.
+  /// The width of the image is calculated from [pixels] length.
   ///
   /// [deviceOrientationType] is the device orientation.
   /// It can be obtained from CameraController of the camera package.
@@ -304,12 +307,13 @@ class NcnnYolox {
   ///
   DetectResults detectBGRA8888({
     required Uint8List pixels,
-    required int width,
     required int height,
     required KannaRotateDeviceOrientationType deviceOrientationType,
     required int sensorOrientation,
     void Function(ui.Image image)? onDecodeImage,
   }) {
+    final width = pixels.length ~/ height ~/ 4;
+
     final rotated = kannaRotate(
       pixels: pixels,
       pixelChannel: PixelChannel.c4,


### PR DESCRIPTION
Strange that `image.width` and `plans[0].bytesPerRow` are different in Pixel4.
https://github.com/KoheiKanagu/ncnn_yolox_flutter/issues/25#issue-1247467611

Maybe it is a bug in the camera plugin since Pixel4 is equipped with a telephoto lens.
The image.width is considered unreliable and is calculated from bytesPerRow.


## maybe related issues
- https://github.com/flutter/flutter/issues/58163
- https://github.com/flutter/flutter/issues/78247